### PR TITLE
Fix: Corrige ReferenceError y actualiza URL de API para posts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,24 +23,30 @@ function AppContent() {
     openAuthModal,
     closeAuthModal,
     handleAuthSuccess,
-    tweets,
-    handleNewTweet,
-    handleLikeTweet,
-    handleRetweetTweet,
-    handleReplyTweet,
-    handleDeleteTweet,
-    handleEditTweet,
-    bookmarkedTweets,
-    handleBookmarkTweet,
-    isTweetBookmarked, // Added from context
+    // --- Nuevos valores del contexto para posts ---
+    posts, // En lugar de tweets
+    // handleNewPost, // Si AppContent lo necesitara directamente
+    // loadingPosts,
+    // errorPosts,
+    // fetchPosts,
+    // --- Fin nuevos valores ---
+    // --- Valores comentados/eliminados del contexto ---
+    // handleLikeTweet, (y similares, ahora comentados en AppContext)
+    // bookmarkedTweets, (comentado en AppContext)
+    // isTweetBookmarked, (comentado en AppContext)
+    // --- Fin valores comentados ---
     activeTab,
     setActiveTab,
-    // showToast is available from context but Toast component itself needs state
+    showToast: contextShowToast // Renombrar para evitar conflicto con el estado local 'toast'
   } = useAppContext();
 
   // Local state for Toast component visibility and content
-  const [toast, setToast] = useState<{ message: string; type: 'success' | 'info' | 'error' } | null>(null);
-  const contextShowToast = useAppContext().showToast; // Get showToast from context
+  // const [toast, setToast] = useState<{ message: string; type: 'success' | 'info' | 'error' } | null>(null);
+  // El manejo del toast se simplificará o se hará directamente con el del contexto si es posible.
+  // Por ahora, el showToast del contexto es el que se usa en los hooks.
+  // App.tsx renderiza el Toast, pero su estado de visibilidad y contenido debe venir del contexto.
+  // Esto ya se maneja con internalToast y el useEffect que reacciona a toastInfo de AppContext (si se implementa así).
+  // El `contextShowToast` de arriba ya es la función de `showToast` del `AppContext`.
 
   // Effect to manage toast display based on context's request
   // This is a bit of a workaround. Ideally, Toast rendering is part of AppContext or a dedicated ToastContext
@@ -123,10 +129,8 @@ function AppContent() {
       case 'home':
         return <Feed />; // Feed ya obtiene posts del contexto
       case 'explore':
-        // Explore necesitará ser adaptado para usar `posts` y `PostData` si se mantiene.
-        // Por ahora, podría fallar o mostrar datos incorrectos si espera la estructura de `Tweet`.
-        // De momento, vamos a dejarlo así y luego se puede revisar.
-        return <Explore tweets={posts} />; // Pasando posts, pero Explore internamente espera Tweets
+        // Explore ya fue adaptado para tomar 'posts' del contexto.
+        return <Explore />;
       case 'notifications':
         if (!appUser) return <div className="p-4 text-center text-gray-500 dark:text-gray-400">Inicia sesión para ver notificaciones.</div>;
         return <Notifications />;
@@ -137,11 +141,11 @@ function AppContent() {
         // Bookmarks también necesitará una refactorización mayor para PostData y nueva lógica de backend.
         // Comentado/simplificado por ahora.
         if (!appUser) return <div className="p-4 text-center text-gray-500 dark:text-gray-400">Inicia sesión para ver tus bookmarks.</div>;
-        // return <Bookmarks tweets={posts.filter(post => isTweetBookmarked(post.id))} />;
         return <div className="p-4 text-center text-gray-500 dark:text-gray-400">Bookmarks (Próximamente)</div>;
       case 'profile':
+        // Profile ya fue adaptado para tomar 'appUser' y 'posts' del contexto.
         if (!appUser) return <div className="p-4 text-center text-gray-500 dark:text-gray-400">Inicia sesión para ver tu perfil.</div>;
-        return <Profile user={appUser} tweets={userPosts} />; // Pasando userPosts. Profile necesitará adaptarse a PostData.
+        return <Profile />;
       case 'settings':
         return <Settings />;
       default:

--- a/src/hooks/usePosts.ts
+++ b/src/hooks/usePosts.ts
@@ -1,8 +1,8 @@
 // src/hooks/usePosts.ts
 import { useState, useCallback, useEffect } from 'react';
-import { PostData, User as AppUser } from '../types'; // Renamed User to AppUser for clarity if needed, using PostData
+import { PostData, User as AppUser } from '../types';
 
-const API_URL = 'http://localhost:3000/posts';
+const API_URL = 'http://localhost:3000/api/posts'; // Actualizada la URL
 
 export const usePosts = (appUser: AppUser | null, showToast: (message: string, type?: 'success' | 'info' | 'error') => void) => {
   const [posts, setPosts] = useState<PostData[]>([]);


### PR DESCRIPTION
- Soluciona ReferenceError al ajustar cómo App.tsx maneja las props para los componentes Explore y Profile, asegurando que obtengan datos del contexto como se espera.
- Actualiza la API_URL en usePosts.ts a 'http://localhost:3000/api/posts' según la especificación del backend.
- Confirma que Profile.tsx consume appUser correctamente desde el contexto.